### PR TITLE
🩹Fix CI setup - replace `docker-compose` with `docker compose`

### DIFF
--- a/.github/workflows/integrationtests.yml
+++ b/.github/workflows/integrationtests.yml
@@ -34,7 +34,7 @@ jobs:
         # Tokens will expire 2025-01-31
         run: echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ secrets.GHCR_USR }} --password-stdin
       - name: Start containers
-        run: docker-compose -f "TransformerBeeClient/TransformerBeeClient.IntegrationTest/docker-compose.yml" up -d
+        run: docker compose -f "TransformerBeeClient/TransformerBeeClient.IntegrationTest/docker-compose.yml" up -d
 
       - name: Install dependencies
         working-directory: TransformerBeeClient

--- a/.github/workflows/release_nuget.yml
+++ b/.github/workflows/release_nuget.yml
@@ -28,7 +28,7 @@ jobs:
         # Tokens will expire 2025-01-31
         run: echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u ${{ secrets.GHCR_USR }} --password-stdin
       - name: Start containers
-        run: docker-compose -f "TransformerBeeClient/TransformerBeeClient.IntegrationTest/docker-compose.yml" up -d
+        run: docker compose -f "TransformerBeeClient/TransformerBeeClient.IntegrationTest/docker-compose.yml" up -d
       - name: Run Unit Tests (dotnet test) # never ever release with failing tests!
         working-directory: "TransformerBeeClient"
         run: dotnet test --configuration Release


### PR DESCRIPTION
### Failing CI due to `docker-compose ... command not found`

> Die Lösung ist wohl, dass man "docker compose" ohne den bindestrich verwendet.
> Und das Problem tritt dann auf, wenn man ubuntu-latest als OS der Action
> verwendet und dieses ungepinnte "latest" ein falsches latest ist.

\- @hf-kklein

*This PR was generated using [multi-gitter](https://github.com/lindell/multi-gitter)*